### PR TITLE
[#148] Add try/except block around code adding labels to already existing issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,22 @@ Thank you for your interest in the firewatch project! Please find some informati
 
 ## Getting Started
 
+### Jira User Permissions
+
+Firewatch can be used with any user in a Jira instance, but that user will need to have proper permissions in the project
+they are reporting to. The user should be able to:
+
+- Create issues
+- Add comments to issues
+- Add attachments to issues
+- Edit issues
+- Transition issues (this only happens when a "success" issue is created, then immediately closed)
+
+If you are using firewatch in the Red Hat Jira instance, the default user is `firewatch-tool`.
+
+If you are encountering permissions issues, please add the user to the project you are reporting to under the role you
+would like to choose. Typically, if you add the user in the `Developer` role, the tool will work as expected.
+
 ### Usage in OpenShift CI
 
 Reporting issues using this tool in OpenShift CI is very simple, you can do one of the following:

--- a/cli/objects/jira_base.py
+++ b/cli/objects/jira_base.py
@@ -334,5 +334,19 @@ class Jira:
             Issue: A Jira Issue object.
         """
         issue = self.get_issue_by_id_or_key(issue_id_or_key)
-        issue.update(update={"labels": [{"add": label} for label in labels]})
+        try:
+            issue.update(update={"labels": [{"add": label} for label in labels]})
+
+        # Check if the error is a 400 code and potentially due to user permissions.
+        except JIRAError as error:
+            if error.status_code == 400:
+                self.logger.error(
+                    f"Failed to add labels to issue {issue_id_or_key}. Error: {error.text}",
+                )
+                self.logger.info(
+                    "This error could be caused by missing permissions on the Jira user."
+                    'Please see the "Jira User Permissions" section in the README for more information.',
+                )
+            else:
+                raise
         return issue

--- a/cli/objects/jira_base.py
+++ b/cli/objects/jira_base.py
@@ -341,7 +341,7 @@ class Jira:
         except JIRAError as error:
             if error.status_code == 400:
                 self.logger.error(
-                    f"Failed to add labels to issue {issue_id_or_key}. Error: {error.text}",
+                    f"Failed to add labels {labels} to issue {issue_id_or_key}. Error: {error.text}",
                 )
                 self.logger.info(
                     "This error could be caused by missing permissions on the Jira user."


### PR DESCRIPTION
We have noticed when adding a new label to an already existing issue in Jira that the permissions on the `firewatch-tool` user needed to be updated in our projects. This PR adds some logging around this issue to help users who may not be familiar with the problem. It also adds some specific documentation to the README to help resolve the problem or tell new users what is required before using the tool.

Closes #148 