### PR TITLE
revert changes to failure matching logic in failure_rule.py.

### DIFF
--- a/cli/objects/failure_rule.py
+++ b/cli/objects/failure_rule.py
@@ -192,5 +192,8 @@ class FailureRule(Rule):
         return (
             hasattr(self, "step")
             and fnmatch.fnmatch(failure.step, self.step)
-            and failure.failure_type in (self.failure_type, "all")
+            and (
+                (failure.failure_type == self.failure_type)
+                or self.failure_type == "all"
+            )
         )


### PR DESCRIPTION
Fixes #151
See [INTEROP-7264](https://issues.redhat.com/browse/INTEROP-7264)

