### PR TITLE
Catch xml.etree.ElementTree ParseError exception from an invalid XML file

### DIFF
--- a/cli/objects/job.py
+++ b/cli/objects/job.py
@@ -16,9 +16,9 @@
 #
 import json
 import os
-from xml.etree.ElementTree import ParseError
 from typing import Any
 from typing import Optional
+from xml.etree.ElementTree import ParseError
 
 import junitparser
 from google.cloud import storage

--- a/cli/objects/job.py
+++ b/cli/objects/job.py
@@ -16,6 +16,7 @@
 #
 import json
 import os
+from xml.etree.ElementTree import ParseError
 from typing import Any
 from typing import Optional
 
@@ -418,7 +419,7 @@ class Job:
                 file_path = os.path.join(root, file)
                 try:
                     junit_xml = junitparser.JUnitXml.fromfile(file_path)
-                except junitparser.junitparser.JUnitXmlError:
+                except (ParseError, junitparser.junitparser.JUnitXmlError):
                     self.logger.warning(
                         f"Attempted to parse {file_path}, but it doesn't seem to be a JUnit results file.",
                     )


### PR DESCRIPTION
Context:
If the test results file contains a broken XML content, the [junitparser command](https://github.com/RedHatQE/firewatch/blob/main/cli/objects/job.py#L420) will fail with a:
`xml.etree.ElementTree.ParseError: syntax error: ..` failure.

See job failure example: https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-mtc-qe-mtc-e2e-qev2-master-mtc1.8-ocp4.15-lp-interop-mtc-interop-aws/1756921885850865664#1:build-log.txt%3A93

This happens especially when we modify the test results with replacing it's content with a string contains:
`"This file contained potentially sensitive information and has been removed.\\n"
`

REF:
https://redhat-internal.slack.com/archives/C04PK4QPSR1/p1707747454327419