### PR TITLE
Correct URL getting logged to be the right address

### DIFF
--- a/src/report/report.py
+++ b/src/report/report.py
@@ -680,7 +680,7 @@ class Report:
         if len(open_bugs) > 0:
             self.logger.info(f"Found open bugs for job {job_name}:")
             for bug in open_bugs:
-                self.logger.info(f"{jira.url}browse/{bug}")
+                self.logger.info(f"{jira.url}/browse/{bug}")
 
             return open_bugs
         else:


### PR DESCRIPTION
The URL that was getting logged was incorrect in one location and was missing a /
This updates the URL to be correct