### PR TITLE
Fix #133: prevent further handling of failures marked as ignored

### DIFF
--- a/src/objects/job.py
+++ b/src/objects/job.py
@@ -338,8 +338,13 @@ class Job:
                 unique_steps_with_failures.add(failure.step)
                 if failure_rules := self.firewatch_config.failure_rules:
                     for rule in failure_rules:
-                        failure.ignore = rule.matches_failure(failure) and rule.ignore
-                failures_list.append(failure)
+                        if rule.matches_failure(failure) and rule.ignore:
+                            self.logger.warning(
+                                f"Ignoring detected {failure.failure_type} in step {failure.step}",
+                            )
+                            failure.ignore = True
+                if not failure.ignore:
+                    failures_list.append(failure)
 
         if len(failures_list) > 0:
             return failures_list

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -77,11 +77,26 @@ def jira_project(monkeypatch):
 
 
 @pytest.fixture(autouse=True)
-def jira_config_path(tmp_path, jira_token, jira_server_url):
+def templates_path():
+    yield Path(__file__).parent.joinpath("templates")
+
+
+@pytest.fixture(autouse=True)
+def jira_configs_templates_path(templates_path):
+    yield templates_path.joinpath("jira_configs")
+
+
+@pytest.fixture(autouse=True)
+def firewatch_configs_templates_path(templates_path):
+    yield templates_path.joinpath("firewatch_configs")
+
+
+@pytest.fixture(autouse=True)
+def jira_config_path(tmp_path, jira_configs_templates_path, jira_token, jira_server_url):
     path = tmp_path.joinpath("jira.config")
     path.parent.mkdir(exist_ok=True, parents=True)
     loader = Environment(
-        loader=FileSystemLoader("src/templates"),
+        loader=FileSystemLoader(jira_configs_templates_path.as_posix()),
         autoescape=select_autoescape(),
     )
     template = loader.get_template("jira.config.j2")

--- a/tests/e2e/templates/jira_configs/jira.config.j2
+++ b/tests/e2e/templates/jira_configs/jira.config.j2
@@ -1,0 +1,10 @@
+{
+    "token": "{{ token }}",
+    {% if "stage" in server_url %}
+    "proxies": {
+        "http": "http://squid.corp.redhat.com:3128",
+        "https": "http://squid.corp.redhat.com:3128"
+    },
+    {% endif %}
+    "url": "{{ server_url }}"
+}

--- a/tests/unittests/conftest.py
+++ b/tests/unittests/conftest.py
@@ -226,6 +226,31 @@ def patch_job_junit_dir(monkeypatch, job_artifacts_dir):
 
 
 @pytest.fixture
+def patch_job_download_dirs(monkeypatch, job_artifacts_dir, patch_job_junit_dir, patch_job_log_dir):
+    LOGGER.info("Patching Job download dir path")
+
+    def _get_download_path(*args, **kwargs):
+        return job_artifacts_dir.parent.as_posix()
+
+    monkeypatch.setattr(Job, "_get_download_path", _get_download_path)
+
+
+@pytest.fixture
+def job_step_names():
+    return []
+
+
+@pytest.fixture
+def patch_job_get_steps(monkeypatch, job_step_names):
+    LOGGER.info("Patching Job step names")
+
+    def _get_steps(*args, **kwargs):
+        return job_step_names
+
+    monkeypatch.setattr(Job, "_get_steps", _get_steps)
+
+
+@pytest.fixture
 def fake_log_secret_path(job_log_dir):
     yield job_log_dir.joinpath("fake-step/fake_build_log.txt")
 
@@ -304,7 +329,9 @@ def artifact_dir(monkeypatch, tmp_path):
 
 @pytest.fixture
 def job_dir(tmp_path, build_id):
-    yield tmp_path / build_id
+    path = tmp_path / build_id
+    path.mkdir(parents=True, exist_ok=True)
+    yield path
 
 
 @pytest.fixture(params=BUILD_IDS_TO_TEST, ids=BUILD_IDS_TO_TEST)


### PR DESCRIPTION
log warning message when ignored failures are marked.
fix and update unittests for bug #133.
add e2e test for bug #133.

fixes #133
see [LPTOCPCI-1202](https://issues.redhat.com/browse/LPTOCPCI-1202)