### PR TITLE
Catch and log `JIRAError` exceptions that occur during attachment upl…

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -355,34 +355,35 @@ tests = ["asttokens (>=2.1.0)", "coverage", "coverage-enable-subprocess", "ipyth
 
 [[package]]
 name = "filelock"
-version = "3.13.1"
+version = "3.13.3"
 description = "A platform independent file lock."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "filelock-3.13.1-py3-none-any.whl", hash = "sha256:57dbda9b35157b05fb3e58ee91448612eb674172fab98ee235ccb0b5bee19a1c"},
-    {file = "filelock-3.13.1.tar.gz", hash = "sha256:521f5f56c50f8426f5e03ad3b281b490a87ef15bc6c526f168290f0c7148d44e"},
+    {file = "filelock-3.13.3-py3-none-any.whl", hash = "sha256:5ffa845303983e7a0b7ae17636509bc97997d58afeafa72fb141a17b152284cb"},
+    {file = "filelock-3.13.3.tar.gz", hash = "sha256:a79895a25bbefdf55d1a2a0a80968f7dbb28edcd6d4234a0afb3f37ecde4b546"},
 ]
 
 [package.extras]
-docs = ["furo (>=2023.9.10)", "sphinx (>=7.2.6)", "sphinx-autodoc-typehints (>=1.24)"]
-testing = ["covdefaults (>=2.3)", "coverage (>=7.3.2)", "diff-cover (>=8)", "pytest (>=7.4.3)", "pytest-cov (>=4.1)", "pytest-mock (>=3.12)", "pytest-timeout (>=2.2)"]
+docs = ["furo (>=2023.9.10)", "sphinx (>=7.2.6)", "sphinx-autodoc-typehints (>=1.25.2)"]
+testing = ["covdefaults (>=2.3)", "coverage (>=7.3.2)", "diff-cover (>=8.0.1)", "pytest (>=7.4.3)", "pytest-cov (>=4.1)", "pytest-mock (>=3.12)", "pytest-timeout (>=2.2)"]
 typing = ["typing-extensions (>=4.8)"]
 
 [[package]]
 name = "google-api-core"
-version = "2.17.1"
+version = "2.18.0"
 description = "Google API client core library"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "google-api-core-2.17.1.tar.gz", hash = "sha256:9df18a1f87ee0df0bc4eea2770ebc4228392d8cc4066655b320e2cfccb15db95"},
-    {file = "google_api_core-2.17.1-py3-none-any.whl", hash = "sha256:610c5b90092c360736baccf17bd3efbcb30dd380e7a6dc28a71059edb8bd0d8e"},
+    {file = "google-api-core-2.18.0.tar.gz", hash = "sha256:62d97417bfc674d6cef251e5c4d639a9655e00c45528c4364fbfebb478ce72a9"},
+    {file = "google_api_core-2.18.0-py3-none-any.whl", hash = "sha256:5a63aa102e0049abe85b5b88cb9409234c1f70afcda21ce1e40b285b9629c1d6"},
 ]
 
 [package.dependencies]
 google-auth = ">=2.14.1,<3.0.dev0"
 googleapis-common-protos = ">=1.56.2,<2.0.dev0"
+proto-plus = ">=1.22.3,<2.0.0dev"
 protobuf = ">=3.19.5,<3.20.0 || >3.20.0,<3.20.1 || >3.20.1,<4.21.0 || >4.21.0,<4.21.1 || >4.21.1,<4.21.2 || >4.21.2,<4.21.3 || >4.21.3,<4.21.4 || >4.21.4,<4.21.5 || >4.21.5,<5.0.0.dev0"
 requests = ">=2.18.0,<3.0.0.dev0"
 
@@ -393,13 +394,13 @@ grpcio-gcp = ["grpcio-gcp (>=0.2.2,<1.0.dev0)"]
 
 [[package]]
 name = "google-auth"
-version = "2.28.2"
+version = "2.29.0"
 description = "Google Authentication Library"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "google-auth-2.28.2.tar.gz", hash = "sha256:80b8b4969aa9ed5938c7828308f20f035bc79f9d8fb8120bf9dc8db20b41ba30"},
-    {file = "google_auth-2.28.2-py2.py3-none-any.whl", hash = "sha256:9fd67bbcd40f16d9d42f950228e9cf02a2ded4ae49198b27432d0cded5a74c38"},
+    {file = "google-auth-2.29.0.tar.gz", hash = "sha256:672dff332d073227550ffc7457868ac4218d6c500b155fe6cc17d2b13602c360"},
+    {file = "google_auth-2.29.0-py2.py3-none-any.whl", hash = "sha256:d452ad095688cd52bae0ad6fafe027f6a6d6f560e810fec20914e17a09526415"},
 ]
 
 [package.dependencies]
@@ -698,13 +699,13 @@ i18n = ["Babel (>=2.7)"]
 
 [[package]]
 name = "jira"
-version = "3.6.0"
+version = "3.8.0"
 description = "Python library for interacting with JIRA via REST APIs."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "jira-3.6.0-py3-none-any.whl", hash = "sha256:08b28388ee498542ebb6b05db87e6c46c37535c268717ccc23c84b377ea309fb"},
-    {file = "jira-3.6.0.tar.gz", hash = "sha256:4c67497fe8dc2f60f1c4f7b33479f059c928bec3db9dcb5cd7b6a09b6ecc0942"},
+    {file = "jira-3.8.0-py3-none-any.whl", hash = "sha256:12190dc84dad00b8a6c0341f7e8a254b0f38785afdec022bd5941e1184a5a3fb"},
+    {file = "jira-3.8.0.tar.gz", hash = "sha256:63719c529a570aaa01c3373dbb5a104dab70381c5be447f6c27f997302fa335a"},
 ]
 
 [package.dependencies]
@@ -1046,6 +1047,23 @@ files = [
 wcwidth = "*"
 
 [[package]]
+name = "proto-plus"
+version = "1.23.0"
+description = "Beautiful, Pythonic protocol buffers."
+optional = false
+python-versions = ">=3.6"
+files = [
+    {file = "proto-plus-1.23.0.tar.gz", hash = "sha256:89075171ef11988b3fa157f5dbd8b9cf09d65fffee97e29ce403cd8defba19d2"},
+    {file = "proto_plus-1.23.0-py3-none-any.whl", hash = "sha256:a829c79e619e1cf632de091013a4173deed13a55f326ef84f05af6f50ff4c82c"},
+]
+
+[package.dependencies]
+protobuf = ">=3.19.0,<5.0.0dev"
+
+[package.extras]
+testing = ["google-api-core[grpc] (>=1.31.5)"]
+
+[[package]]
 name = "protobuf"
 version = "4.25.3"
 description = ""
@@ -1092,28 +1110,28 @@ tests = ["pytest"]
 
 [[package]]
 name = "pyasn1"
-version = "0.5.1"
+version = "0.6.0"
 description = "Pure-Python implementation of ASN.1 types and DER/BER/CER codecs (X.208)"
 optional = false
-python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,>=2.7"
+python-versions = ">=3.8"
 files = [
-    {file = "pyasn1-0.5.1-py2.py3-none-any.whl", hash = "sha256:4439847c58d40b1d0a573d07e3856e95333f1976294494c325775aeca506eb58"},
-    {file = "pyasn1-0.5.1.tar.gz", hash = "sha256:6d391a96e59b23130a5cfa74d6fd7f388dbbe26cc8f1edf39fdddf08d9d6676c"},
+    {file = "pyasn1-0.6.0-py2.py3-none-any.whl", hash = "sha256:cca4bb0f2df5504f02f6f8a775b6e416ff9b0b3b16f7ee80b5a3153d9b804473"},
+    {file = "pyasn1-0.6.0.tar.gz", hash = "sha256:3a35ab2c4b5ef98e17dfdec8ab074046fbda76e281c5a706ccd82328cfc8f64c"},
 ]
 
 [[package]]
 name = "pyasn1-modules"
-version = "0.3.0"
+version = "0.4.0"
 description = "A collection of ASN.1-based protocols modules"
 optional = false
-python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,>=2.7"
+python-versions = ">=3.8"
 files = [
-    {file = "pyasn1_modules-0.3.0-py2.py3-none-any.whl", hash = "sha256:d3ccd6ed470d9ffbc716be08bd90efbd44d0734bc9303818f7336070984a162d"},
-    {file = "pyasn1_modules-0.3.0.tar.gz", hash = "sha256:5bd01446b736eb9d31512a30d46c1ac3395d676c6f3cafa4c03eb54b9925631c"},
+    {file = "pyasn1_modules-0.4.0-py3-none-any.whl", hash = "sha256:be04f15b66c206eed667e0bb5ab27e2b1855ea54a842e5037738099e8ca4ae0b"},
+    {file = "pyasn1_modules-0.4.0.tar.gz", hash = "sha256:831dbcea1b177b28c9baddf4c6d1013c24c3accd14a1873fffaa6a2e905f17b6"},
 ]
 
 [package.dependencies]
-pyasn1 = ">=0.4.6,<0.6.0"
+pyasn1 = ">=0.4.6,<0.7.0"
 
 [[package]]
 name = "pygments"
@@ -1191,29 +1209,29 @@ testing = ["fields", "hunter", "process-tests", "pytest-xdist", "six", "virtuale
 
 [[package]]
 name = "pytest-mock"
-version = "3.12.0"
+version = "3.14.0"
 description = "Thin-wrapper around the mock package for easier use with pytest"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "pytest-mock-3.12.0.tar.gz", hash = "sha256:31a40f038c22cad32287bb43932054451ff5583ff094bca6f675df2f8bc1a6e9"},
-    {file = "pytest_mock-3.12.0-py3-none-any.whl", hash = "sha256:0972719a7263072da3a21c7f4773069bcc7486027d7e8e1f81d98a47e701bc4f"},
+    {file = "pytest-mock-3.14.0.tar.gz", hash = "sha256:2719255a1efeceadbc056d6bf3df3d1c5015530fb40cf347c0f9afac88410bd0"},
+    {file = "pytest_mock-3.14.0-py3-none-any.whl", hash = "sha256:0b72c38033392a5f4621342fe11e9219ac11ec9d375f8e2a0c164539e0d70f6f"},
 ]
 
 [package.dependencies]
-pytest = ">=5.0"
+pytest = ">=6.2.5"
 
 [package.extras]
 dev = ["pre-commit", "pytest-asyncio", "tox"]
 
 [[package]]
 name = "python-simple-logger"
-version = "1.0.16"
+version = "1.0.19"
 description = "A simple logger for python"
 optional = false
-python-versions = ">=3.8,<4.0"
+python-versions = "<4.0,>=3.8"
 files = [
-    {file = "python_simple_logger-1.0.16.tar.gz", hash = "sha256:392d08358fc0bc0b334eaeb5a81d58568a0abbd6719774de5e71bb1198dca6ad"},
+    {file = "python_simple_logger-1.0.19.tar.gz", hash = "sha256:09e012b7eae28d22cd00725576aac0ec06f283838a57888d4d23b8935fc8092e"},
 ]
 
 [package.dependencies]
@@ -1244,6 +1262,7 @@ files = [
     {file = "PyYAML-6.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:bf07ee2fef7014951eeb99f56f39c9bb4af143d8aa3c21b1677805985307da34"},
     {file = "PyYAML-6.0.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:855fb52b0dc35af121542a76b9a84f8d1cd886ea97c84703eaa6d88e37a2ad28"},
     {file = "PyYAML-6.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:40df9b996c2b73138957fe23a16a4f0ba614f4c0efce1e9406a184b6d07fa3a9"},
+    {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a08c6f0fe150303c1c6b71ebcd7213c2858041a7e01975da3a99aed1e7a378ef"},
     {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6c22bec3fbe2524cde73d7ada88f6566758a8f7227bfbf93a408a9d86bcc12a0"},
     {file = "PyYAML-6.0.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8d4e9c88387b0f5c7d5f281e55304de64cf7f9c0021a3525bd3b1c542da3b0e4"},
     {file = "PyYAML-6.0.1-cp312-cp312-win32.whl", hash = "sha256:d483d2cdf104e7c9fa60c544d92981f12ad66a457afae824d146093b8c294c54"},
@@ -1301,13 +1320,13 @@ use-chardet-on-py3 = ["chardet (>=3.0.2,<6)"]
 
 [[package]]
 name = "requests-oauthlib"
-version = "1.4.0"
+version = "2.0.0"
 description = "OAuthlib authentication support for Requests."
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+python-versions = ">=3.4"
 files = [
-    {file = "requests-oauthlib-1.4.0.tar.gz", hash = "sha256:acee623221e4a39abcbb919312c8ff04bd44e7e417087fb4bd5e2a2f53d5e79a"},
-    {file = "requests_oauthlib-1.4.0-py2.py3-none-any.whl", hash = "sha256:7a3130d94a17520169e38db6c8d75f2c974643788465ecc2e4b36d288bf13033"},
+    {file = "requests-oauthlib-2.0.0.tar.gz", hash = "sha256:b3dffaebd884d8cd778494369603a9e7b58d29111bf6b41bdc2dcd87203af4e9"},
+    {file = "requests_oauthlib-2.0.0-py2.py3-none-any.whl", hash = "sha256:7dd8a5c40426b779b0868c404bdef9768deccf22749cde15852df527e6269b36"},
 ]
 
 [package.dependencies]
@@ -1404,13 +1423,13 @@ files = [
 
 [[package]]
 name = "tox"
-version = "4.14.1"
+version = "4.14.2"
 description = "tox is a generic virtualenv management and test command line tool"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "tox-4.14.1-py3-none-any.whl", hash = "sha256:b03754b6ee6dadc70f2611da82b4ed8f625fcafd247e15d1d0cb056f90a06d3b"},
-    {file = "tox-4.14.1.tar.gz", hash = "sha256:f0ad758c3bbf7e237059c929d3595479363c3cdd5a06ac3e49d1dd020ffbee45"},
+    {file = "tox-4.14.2-py3-none-any.whl", hash = "sha256:2900c4eb7b716af4a928a7fdc2ed248ad6575294ed7cfae2ea41203937422847"},
+    {file = "tox-4.14.2.tar.gz", hash = "sha256:0defb44f6dafd911b61788325741cc6b2e12ea71f987ac025ad4d649f1f1a104"},
 ]
 
 [package.dependencies]

--- a/src/objects/jira_base.py
+++ b/src/objects/jira_base.py
@@ -162,7 +162,14 @@ class Jira:
             self.connection.add_attachment(issue=issue.key, attachment=attachment_path)
             self.logger.info(f"Attachment {attachment_path} has been uploaded to {issue}")
         except JIRAError as e:
-            self.logger.exception(msg=e)
+            self.logger.exception(
+                msg=f"""
+            exception caught while attempting to upload attachment to Jira issue:
+                {e=}
+                {issue=}
+                {attachment_path=}
+            """
+            )
 
     def search(self, jql_query: str) -> list[Any]:
         """

--- a/src/objects/jira_base.py
+++ b/src/objects/jira_base.py
@@ -121,8 +121,7 @@ class Jira:
 
         if file_attachments is not None:
             for file_path in file_attachments:
-                self.connection.add_attachment(issue=issue.key, attachment=file_path)
-                self.logger.info(f"Attachment {file_path} has been uploaded to {issue}")
+                self.add_attachment_to_issue(issue=issue, attachment_path=file_path)
 
         if epic is not None:
             epic_search = self.connection.search_issues(f'issue="{epic}"', maxResults=False)
@@ -147,6 +146,23 @@ class Jira:
             )
 
         return issue
+
+    def add_attachment_to_issue(self, issue: Issue, attachment_path: str) -> None:
+        """
+        Add and upload the attachment from attachment_path to the Jira Issue object provided.
+
+        Args:
+            issue (Issue): The Jira issue the attachment should be added to.
+            attachment_path (str): The path of the file to upload as an attachment to the issue.
+
+        Returns:
+            None
+        """
+        try:
+            self.connection.add_attachment(issue=issue.key, attachment=attachment_path)
+            self.logger.info(f"Attachment {attachment_path} has been uploaded to {issue}")
+        except JIRAError as e:
+            self.logger.exception(msg=e)
 
     def search(self, jql_query: str) -> list[Any]:
         """

--- a/tests/unittests/conftest.py
+++ b/tests/unittests/conftest.py
@@ -511,8 +511,7 @@ def patch_jira_api_requests(
         else:
             LOGGER.info(f"Unpatched POST request to: {url}")
             monkeypatch.undo()
-            r = requests.sessions.Session.post(self=self, url=url, *args, **kwargs)
-            return r
+            return requests.sessions.Session.post(self=self, url=url, *args, **kwargs)
 
     def put(self, url, data, *args, **kwargs):
         LOGGER.info(f"Patching PUT request to URL: {url}")

--- a/tests/unittests/conftest.py
+++ b/tests/unittests/conftest.py
@@ -530,6 +530,7 @@ def patch_jira_api_requests(
             LOGGER.info(f"Unpatched PUT request to: {url}")
             monkeypatch.undo()
             return requests.sessions.Session.put(self, url, *args, **kwargs)
+
     monkeypatch.setattr(requests.sessions.Session, "get", get)
     monkeypatch.setattr(requests.sessions.Session, "post", post)
     monkeypatch.setattr(requests.sessions.Session, "put", put)

--- a/tests/unittests/conftest.py
+++ b/tests/unittests/conftest.py
@@ -529,9 +529,7 @@ def patch_jira_api_requests(
         else:
             LOGGER.info(f"Unpatched PUT request to: {url}")
             monkeypatch.undo()
-            r = requests.sessions.Session.put(self, url, *args, **kwargs)
-            return r
-
+            return requests.sessions.Session.put(self, url, *args, **kwargs)
     monkeypatch.setattr(requests.sessions.Session, "get", get)
     monkeypatch.setattr(requests.sessions.Session, "post", post)
     monkeypatch.setattr(requests.sessions.Session, "put", put)

--- a/tests/unittests/objects/jira/test_jira.py
+++ b/tests/unittests/objects/jira/test_jira.py
@@ -1,11 +1,52 @@
+import pytest
 from jira import Issue
 
 
-def test_get_issue_by_id_returns_jira_issue_from_jira_api_client_with_matching_issue_id(
-    patch_jira_api_requests,
-    jira,
-    fake_issue_id,
-):
+@pytest.fixture
+def fake_issue_add_attachment_response(mock_jira_api_response, jira):
+    yield mock_jira_api_response(
+        _content=b'{"errorMessages": ["You do not have permission to create attachments for this issue."], "errors": {}}',
+        _status_code=403,
+    )
+
+
+@pytest.fixture
+def jira(patch_jira_api_requests, jira):
+    jira._caps = patch_jira_api_requests
+    yield jira
+
+
+@pytest.fixture
+def fake_issue(fake_issue_id, jira) -> Issue:
+    yield jira.get_issue_by_id_or_key(issue=fake_issue_id)
+
+
+@pytest.fixture
+def fake_attachment_path(tmp_path):
+    path = tmp_path.joinpath("build_log.json")
+    path.write_text("anything")
+    yield path
+
+
+def test_get_issue_by_id_returns_jira_issue_from_jira_api_client_with_matching_issue_id(fake_issue_id, jira):
     issue = jira.get_issue_by_id_or_key(issue=fake_issue_id)
     assert isinstance(issue, Issue)
     assert issue.id == fake_issue_id
+
+
+def test_add_file_attachment_with_success(fake_issue, jira, fake_attachment_path):
+    jira.add_attachment_to_issue(
+        issue=fake_issue,
+        attachment_path=fake_attachment_path.as_posix(),
+    )
+
+
+def test_add_file_attachment_with_permission_failure_logs_failure_without_raising_exception(
+    fake_issue, fake_issue_add_attachment_response, jira, fake_attachment_path, caplog
+):
+    jira.logger.handlers[0] = caplog.handler
+    jira.add_attachment_to_issue(
+        issue=fake_issue,
+        attachment_path=fake_attachment_path.as_posix(),
+    )
+    assert "You do not have permission to create attachments for this issue" in caplog.text

--- a/tests/unittests/objects/jira/test_jira.py
+++ b/tests/unittests/objects/jira/test_jira.py
@@ -3,15 +3,8 @@ from jira import Issue
 
 
 @pytest.fixture
-def fake_issue_add_attachment_response(mock_jira_api_response, jira):
-    yield mock_jira_api_response(
-        _content=b'{"errorMessages": ["You do not have permission to create attachments for this issue."], "errors": {}}',
-        _status_code=403,
-    )
-
-
-@pytest.fixture
-def jira(patch_jira_api_requests, jira):
+def jira(patch_jira_api_requests, jira, caplog):
+    jira.logger.handlers[0] = caplog.handler
     jira._caps = patch_jira_api_requests
     yield jira
 
@@ -28,25 +21,33 @@ def fake_attachment_path(tmp_path):
     yield path
 
 
-def test_get_issue_by_id_returns_jira_issue_from_jira_api_client_with_matching_issue_id(fake_issue_id, jira):
-    issue = jira.get_issue_by_id_or_key(issue=fake_issue_id)
-    assert isinstance(issue, Issue)
-    assert issue.id == fake_issue_id
+class TestJiraApiRespondsWithSuccess:
+    def test_get_issue_by_id_returns_jira_issue_from_jira_api_client_with_matching_issue_id(self, fake_issue_id, jira):
+        issue = jira.get_issue_by_id_or_key(issue=fake_issue_id)
+        assert isinstance(issue, Issue)
+        assert issue.id == fake_issue_id
+
+    def test_add_file_attachment_with_success_and_log(self, fake_issue, jira, fake_attachment_path, caplog):
+        jira.add_attachment_to_issue(
+            issue=fake_issue,
+            attachment_path=fake_attachment_path.as_posix(),
+        )
+        assert f"Attachment {fake_attachment_path} has been uploaded to {fake_issue.key}" in caplog.text
 
 
-def test_add_file_attachment_with_success(fake_issue, jira, fake_attachment_path):
-    jira.add_attachment_to_issue(
-        issue=fake_issue,
-        attachment_path=fake_attachment_path.as_posix(),
-    )
+class TestJiraApiRespondsWithPermissionFailure:
+    @pytest.fixture
+    def fake_issue_add_attachment_response(self, mock_jira_api_response):
+        yield mock_jira_api_response(
+            _content=b'{"errorMessages": ["You do not have permission to create attachments for this issue."], "errors": {}}',
+            _status_code=403,
+        )
 
-
-def test_add_file_attachment_with_permission_failure_logs_failure_without_raising_exception(
-    fake_issue, fake_issue_add_attachment_response, jira, fake_attachment_path, caplog
-):
-    jira.logger.handlers[0] = caplog.handler
-    jira.add_attachment_to_issue(
-        issue=fake_issue,
-        attachment_path=fake_attachment_path.as_posix(),
-    )
-    assert "You do not have permission to create attachments for this issue" in caplog.text
+    def test_add_file_attachment_with_permission_failure_logs_failure_without_raising_exception(
+        self, fake_issue, jira, fake_attachment_path, caplog
+    ):
+        jira.add_attachment_to_issue(
+            issue=fake_issue,
+            attachment_path=fake_attachment_path.as_posix(),
+        )
+        assert "You do not have permission to create attachments for this issue" in caplog.text

--- a/tests/unittests/resources/templates/jira_api/fake_issue_add_attachment_response.json
+++ b/tests/unittests/resources/templates/jira_api/fake_issue_add_attachment_response.json
@@ -1,0 +1,44 @@
+[
+    {
+        "self": "http://www.example.com/jira/rest/api/2.0/attachments/10000",
+        "filename": "picture.jpg",
+        "author": {
+            "self": "http://www.example.com/jira/rest/api/2/user?username=fred",
+            "name": "fred",
+            "avatarUrls": {
+                "48x48": "http://www.example.com/jira/secure/useravatar?size=large&ownerId=fred",
+                "24x24": "http://www.example.com/jira/secure/useravatar?size=small&ownerId=fred",
+                "16x16": "http://www.example.com/jira/secure/useravatar?size=xsmall&ownerId=fred",
+                "32x32": "http://www.example.com/jira/secure/useravatar?size=medium&ownerId=fred"
+            },
+            "displayName": "Fred F. User",
+            "active": false
+        },
+        "created": "2017-12-07T09:23:19.542+0000",
+        "size": 23123,
+        "mimeType": "image/jpeg",
+        "content": "http://www.example.com/jira/attachments/10000",
+        "thumbnail": "http://www.example.com/jira/secure/thumbnail/10000"
+    },
+    {
+        "self": "http://www.example.com/jira/rest/api/2.0/attachments/10001",
+        "filename": "dbeuglog.txt",
+        "author": {
+            "self": "http://www.example.com/jira/rest/api/2/user?username=fred",
+            "name": "fred",
+            "avatarUrls": {
+                "48x48": "http://www.example.com/jira/secure/useravatar?size=large&ownerId=fred",
+                "24x24": "http://www.example.com/jira/secure/useravatar?size=small&ownerId=fred",
+                "16x16": "http://www.example.com/jira/secure/useravatar?size=xsmall&ownerId=fred",
+                "32x32": "http://www.example.com/jira/secure/useravatar?size=medium&ownerId=fred"
+            },
+            "displayName": "Fred F. User",
+            "active": false
+        },
+        "created": "2017-12-07T09:23:19.542+0000",
+        "size": 2460,
+        "mimeType": "text/plain",
+        "content": "http://www.example.com/jira/attachments/10001",
+        "thumbnail": "http://www.example.com/jira/secure/thumbnail/10002"
+    }
+]


### PR DESCRIPTION
…oads, preventing run failures that could occur when a file is not successfully added to an issue.

extract `Jira.add_attachment_to_issue` to support unit tests.

add and update Jira unit tests.

add and update test fixtures.

add Jira API response template file.

closes #173 
closes [NTEROP-7326](https://issues.redhat.com/browse/INTEROP-7326)