### PR TITLE
 Add support for Firewatch base config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,7 +37,7 @@ repos:
     - id: detect-secrets
       exclude: tests/unittests/resources/templates/jira_api/fake_server_info.json
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.3.7
+  rev: v0.4.1
   hooks:
     - id: ruff
     - id: ruff-format

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
     - id: check-json
     - id: check-yaml
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v1.9.0
+  rev: v1.10.0
   hooks:
   - id: mypy
     exclude: ^(tests/)
@@ -37,7 +37,7 @@ repos:
     - id: detect-secrets
       exclude: tests/unittests/resources/templates/jira_api/fake_server_info.json
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.4.1
+  rev: v0.4.2
   hooks:
     - id: ruff
     - id: ruff-format

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,7 +37,7 @@ repos:
     - id: detect-secrets
       exclude: tests/unittests/resources/templates/jira_api/fake_server_info.json
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.3.5
+  rev: v0.3.7
   hooks:
     - id: ruff
     - id: ruff-format

--- a/src/objects/configuration.py
+++ b/src/objects/configuration.py
@@ -188,7 +188,7 @@ class Configuration:
         # Include patterns from base config and expend user input
         for key in ["failure_rules", "success_rules"]:
             if key in config_data:
-                steps_map = {d["step"]: d for d in config_data[key]}
+                steps_map = {d.get("step"): d for d in config_data[key]}
             if key in base_config_data:
                 for step_dict in base_config_data[key]:
                     step = step_dict["step"]

--- a/src/objects/configuration.py
+++ b/src/objects/configuration.py
@@ -194,7 +194,7 @@ class Configuration:
                     step = step_dict["step"]
                     if step not in steps_map.keys():
                         # Check if user didn't mention a pattern that already overrides this step
-                        if not any(fnmatch.fnmatch(step,k) for k in steps_map.keys()):
+                        if not any(fnmatch.fnmatch(step, k) for k in steps_map.keys()):
                             if key not in config_data:
                                 config_data[key] = step_dict
                             else:

--- a/src/objects/configuration.py
+++ b/src/objects/configuration.py
@@ -144,14 +144,15 @@ class Configuration:
         Returns:
             dict[Any, Any]: A dictionary object representing the firewatch config data.
         """
-        base_config_data = "{}"
+        base_config_str = ""
+        base_config_data = {}
         steps_map = {}
 
         if base_config_file_path is not None:
             # Read the contents of the config file
             try:
                 with open(base_config_file_path) as file:
-                    base_config_data = file.read()
+                    base_config_str = file.read()
             except Exception:
                 self.logger.error(
                     f"Unable to read configuration file at {base_config_file_path}. Please verify permissions/path and try again.",
@@ -160,7 +161,8 @@ class Configuration:
 
         # Verify that the config data is properly formatted JSON
         try:
-            base_config_data = json.loads(base_config_data)
+            if base_config_str:
+                base_config_data = json.loads(base_config_str)
 
             # Will update base config with additional logic from env vars
             additional_config_data = json.loads(os.getenv("FIREWATCH_CONFIG") or "{}")

--- a/src/objects/configuration.py
+++ b/src/objects/configuration.py
@@ -51,7 +51,7 @@ class Configuration:
         self.verbose_test_failure_reporting_ticket_limit = verbose_test_failure_reporting_ticket_limit
 
         # Get the config data
-        self.config_data = self._get_config_data(config_file_path=config_file_path)
+        self.config_data = self._get_config_data(base_config_file_path=config_file_path)
 
         # Create the lists of Rule objects using the config data
         self.success_rules = self._get_success_rules(
@@ -128,38 +128,40 @@ class Configuration:
             )
             exit(1)
 
-    def _get_config_data(self, config_file_path: Optional[str]) -> dict[Any, Any]:
+    def _get_config_data(self, base_config_file_path: Optional[str]) -> dict[Any, Any]:
         """
-        Gets the config data from either a configuration file or from the FIREWATCH_CONFIG environment variable.
-        Will exit with code 1 if either a config file isn't provided (or isn't able to be read) or the FIREWATCH_CONFIG environment variable isn't set.
+        Gets the config data from either a configuration file or from the FIREWATCH_CONFIG environment variable or
+        both.
+        Will exit with code 1 if both a config file isn't provided (or isn't able to be read) or the FIREWATCH_CONFIG environment variable isn't set.
+        The configuration file is considered as the basis of the configuration data,
+        And it will be overridden and expended by the additional set of rules that will be applied to the env var.
 
         Args:
-            config_file_path (Optional[str]): The firewatch config can be stored in a file or an environment var.
+            base_config_file_path (Optional[str]): The firewatch config can be stored in a file or an environment var.
 
         Returns:
             dict[Any, Any]: A dictionary object representing the firewatch config data.
         """
-        if config_file_path is not None:
+        base_config_data = "{}"
+
+        if base_config_file_path is not None:
             # Read the contents of the config file
             try:
-                with open(config_file_path) as file:
-                    config_data = file.read()
+                with open(base_config_file_path) as file:
+                    base_config_data = file.read()
             except Exception:
                 self.logger.error(
-                    f"Unable to read configuration file at {config_file_path}. Please verify permissions/path and try again.",
-                )
-                exit(1)
-        else:
-            config_data = os.getenv("FIREWATCH_CONFIG")  # type: ignore
-            if not config_data:
-                self.logger.error(
-                    "A configuration file must be provided or the $FIREWATCH_CONFIG environment variable must be set. Please fix error and try again.",
+                    f"Unable to read configuration file at {base_config_file_path}. Please verify permissions/path and try again.",
                 )
                 exit(1)
 
         # Verify that the config data is properly formatted JSON
         try:
-            config_data = json.loads(config_data)
+            base_config_data = json.loads(base_config_data)
+
+            # Will update base config with additional logic from env vars
+            additional_config_data = json.loads(os.getenv("FIREWATCH_CONFIG") or "{}")
+
         except json.decoder.JSONDecodeError as error:
             self.logger.error(
                 "Firewatch config contains malformed JSON. Please check for missing or additional commas:",
@@ -170,4 +172,27 @@ class Configuration:
             )
             exit(1)
 
-        return config_data  # type: ignore
+        for key in ["failure_rules", "success_rules"]:
+            if key in base_config_data:
+                # Create a dict to map keys to dictionaries for quick lookup and update
+                steps_map = {d["step"]: d for d in base_config_data[key]}
+
+            if key in additional_config_data:
+                for dict in additional_config_data[key]:
+                    step = dict["step"]
+                    if step in steps_map:
+                        # If step exists in base config, update and override it
+                        steps_map[step].update(dict)
+                    else:
+                        # Add user input to base config and expend it
+                        base_config_data[key].append(dict)
+                        steps_map[step] = dict  # Also update the key_map to include this new key
+
+        if not base_config_data:
+            self.logger.error(
+                "A configuration file must be provided or the $FIREWATCH_CONFIG environment variable must be set. "
+                "Please fix error and try again.",
+            )
+            exit(1)
+
+        return base_config_data  # type: ignore

--- a/tests/unittests/functions/report/test_firewatch_functions_report_failure_matches_rule.py
+++ b/tests/unittests/functions/report/test_firewatch_functions_report_failure_matches_rule.py
@@ -86,7 +86,7 @@ class TestFailureMatchesRule(ReportBaseTest):
                 "jira_project": "NONE",
             },
         )
-        rules = [match_rule,pattern_rule]
+        rules = [match_rule, pattern_rule]
 
         self.failure.step = "exact-failed-step"
         matching_rules = self.report.failure_matches_rule(
@@ -94,9 +94,9 @@ class TestFailureMatchesRule(ReportBaseTest):
             rules=rules,
             default_jira_project=self.config.default_jira_project,
         )
-        print([s.step for s in matching_rules]) #TODO
+        print([s.step for s in matching_rules])  # TODO
         import ipdb
+
         ipdb.set_trace()
         assert len(matching_rules) == 1
-        assert (matching_rules[0].step == match_rule.step)
-
+        assert matching_rules[0].step == match_rule.step

--- a/tests/unittests/functions/report/test_firewatch_functions_report_failure_matches_rule.py
+++ b/tests/unittests/functions/report/test_firewatch_functions_report_failure_matches_rule.py
@@ -68,3 +68,35 @@ class TestFailureMatchesRule(ReportBaseTest):
         assert (matching_rules[0].step == match_rule.step) and (
             matching_rules[0].failure_type == match_rule.failure_type
         )
+
+    def test_configuration_gets_failure_rules_with_two_matching_steps(self):
+        match_rule = FailureRule(
+            rule_dict={
+                "step": "exact-failed-step",
+                "failure_type": "test_failure",
+                "classification": "NONE",
+                "jira_project": "NONE",
+            },
+        )
+        pattern_rule = FailureRule(
+            rule_dict={
+                "step": "exact-*",
+                "failure_type": "test_failure",
+                "classification": "NONE",
+                "jira_project": "NONE",
+            },
+        )
+        rules = [match_rule,pattern_rule]
+
+        self.failure.step = "exact-failed-step"
+        matching_rules = self.report.failure_matches_rule(
+            failure=self.failure,
+            rules=rules,
+            default_jira_project=self.config.default_jira_project,
+        )
+        print([s.step for s in matching_rules]) #TODO
+        import ipdb
+        ipdb.set_trace()
+        assert len(matching_rules) == 1
+        assert (matching_rules[0].step == match_rule.step)
+

--- a/tests/unittests/functions/report/test_firewatch_functions_report_failure_matches_rule.py
+++ b/tests/unittests/functions/report/test_firewatch_functions_report_failure_matches_rule.py
@@ -103,6 +103,7 @@ class TestFailureMatchesRule(ReportBaseTest):
             rules=rules,
             default_jira_project=self.config.default_jira_project,
         )
-
         # Check if match_rule is sorted higher than pattern_rule
         assert matching_rules[0].step.__eq__(failure.step)
+        # Eliminate the rule with the wrong failure_type
+        assert len(matching_rules) == 2

--- a/tests/unittests/objects/configuration/test_firewatch_objects_configuration_get_config_data.py
+++ b/tests/unittests/objects/configuration/test_firewatch_objects_configuration_get_config_data.py
@@ -61,20 +61,20 @@ class TestGetConfigData(ConfigurationBaseTest):
         os.environ,
         {
             "FIREWATCH_CONFIG": '{"failure_rules": [{"step": "specific-step-pattern","failure_type": "pod_failure",'
-                                '"classification": "none"},{"step": "*step-logic*","failure_type": "pod_failure",'
-                                '"classification": "none"}]}',
+            '"classification": "none"},{"step": "*step-logic*","failure_type": "pod_failure",'
+            '"classification": "none"}]}',
         },
     )
     def test_configuration_gets_config_data_with_base_config_using_patterns(self):
-        base_config_data = ('{"failure_rules": [{"step": "*step-pattern*", "failure_type": "pod_failure", '
-                            '"classification": "none"}, {"step": "old-step-logic", "failure_type": "pod_failure", '
-                            '"classification": "none"}]}')
+        base_config_data = (
+            '{"failure_rules": [{"step": "*step-pattern*", "failure_type": "pod_failure", '
+            '"classification": "none"}, {"step": "old-step-logic", "failure_type": "pod_failure", '
+            '"classification": "none"}]}'
+        )
         with tempfile.TemporaryDirectory() as tmp_path:
             base_config_file = os.path.join(tmp_path, "base_config.json")
             with open(base_config_file, "w") as f:
                 f.write(base_config_data)
             config = Configuration(self.mock_jira, True, True, True, 10, base_config_file)
             new_steps = [rule["step"] for rule in config.config_data["failure_rules"]]
-            assert new_steps == ['specific-step-pattern', '*step-logic*', '*step-pattern*']
-
-
+            assert new_steps == ["specific-step-pattern", "*step-logic*", "*step-pattern*"]

--- a/tests/unittests/objects/configuration/test_firewatch_objects_configuration_get_config_data.py
+++ b/tests/unittests/objects/configuration/test_firewatch_objects_configuration_get_config_data.py
@@ -56,3 +56,25 @@ class TestGetConfigData(ConfigurationBaseTest):
             del os.environ["FIREWATCH_CONFIG"]
         with self.assertRaises(SystemExit):
             Configuration(self.mock_jira, True, True, True, 10, None)
+
+    @patch.dict(
+        os.environ,
+        {
+            "FIREWATCH_CONFIG": '{"failure_rules": [{"step": "specific-step-pattern","failure_type": "pod_failure",'
+                                '"classification": "none"},{"step": "*step-logic*","failure_type": "pod_failure",'
+                                '"classification": "none"}]}',
+        },
+    )
+    def test_configuration_gets_config_data_with_base_config_using_patterns(self):
+        base_config_data = ('{"failure_rules": [{"step": "*step-pattern*", "failure_type": "pod_failure", '
+                            '"classification": "none"}, {"step": "old-step-logic", "failure_type": "pod_failure", '
+                            '"classification": "none"}]}')
+        with tempfile.TemporaryDirectory() as tmp_path:
+            base_config_file = os.path.join(tmp_path, "base_config.json")
+            with open(base_config_file, "w") as f:
+                f.write(base_config_data)
+            config = Configuration(self.mock_jira, True, True, True, 10, base_config_file)
+            new_steps = [rule["step"] for rule in config.config_data["failure_rules"]]
+            assert new_steps == ['specific-step-pattern', '*step-logic*', '*step-pattern*']
+
+

--- a/tests/unittests/objects/configuration/test_firewatch_objects_configuration_get_config_data.py
+++ b/tests/unittests/objects/configuration/test_firewatch_objects_configuration_get_config_data.py
@@ -78,3 +78,8 @@ class TestGetConfigData(ConfigurationBaseTest):
             config = Configuration(self.mock_jira, True, True, True, 10, base_config_file)
             new_steps = [rule["step"] for rule in config.config_data["failure_rules"]]
             assert new_steps == ["specific-step-pattern", "*step-logic*", "*step-pattern*"]
+
+    def test_configuration_gets_config_data_with_base_config_from_invalid_url(self):
+        base_config_file = "https://"
+        with self.assertRaises(SystemExit):
+            Configuration(self.mock_jira, True, True, True, 10, base_config_file)


### PR DESCRIPTION
For occurring steps and workflows in our project, we want to initialize a source that holds our Firewatch base config.

Once set up (optional), our Openshift-ci env `FIREWATCH_CONFIG` values will be added on top of that.

This PR allows the user to override the base config by:
-  replacing steps with general patterns with specific step names and vice versa
-  updating existing rules with new logic. 

For example: 
The team consistently uses the rule `{"step": "failure", "ignore": "True"...}` and holds it in their base config file; a specific scenario might need to override it and set the "ignore" to "False".
in this case, the scenario will mention this step in their `FIREWATCH_CONFIG` env var.

Unit-tests main additions:
- steps containing patterns and steps that matches them are co-existing when configured on the same config data
- config data collected from both base config and additional logic from env var is functioning well