### PR TITLE
Add hierarchy to handle multiple matching rules for a failure

### DIFF
--- a/src/report/report.py
+++ b/src/report/report.py
@@ -350,6 +350,9 @@ class Report:
             if default_rule not in matching_rules:
                 matching_rules.append(default_rule)
 
+        # Sort matching_rules by the identical rules to failure.step
+        if matching_rules:
+            matching_rules = sorted(matching_rules, key=lambda x: x.step.__eq__(failure.step), reverse=True)
         return matching_rules
 
     def add_passing_job_comment(self, job: Job, jira: Jira, issue_id: str) -> None:

--- a/tests/unittests/functions/report/test_firewatch_functions_report_failure_matches_rule.py
+++ b/tests/unittests/functions/report/test_firewatch_functions_report_failure_matches_rule.py
@@ -80,14 +80,6 @@ class TestFailureMatchesRule(ReportBaseTest):
                 "jira_project": "NONE",
             },
         )
-        different_type_rule = FailureRule(
-            rule_dict={
-                "step": "exact-failed-step",
-                "failure_type": "pod_failure",
-                "classification": "NONE",
-                "jira_project": "NONE",
-            },
-        )
         pattern_rule = FailureRule(
             rule_dict={
                 "step": "exact-*",
@@ -96,13 +88,12 @@ class TestFailureMatchesRule(ReportBaseTest):
                 "jira_project": "NONE",
             },
         )
-        rules = [pattern_rule, different_type_rule, match_rule]
+        rules = [pattern_rule, match_rule]
 
         matching_rules = self.report.failure_matches_rule(
             failure=failure,
             rules=rules,
             default_jira_project=self.config.default_jira_project,
         )
-
         # Check if match_rule is sorted higher than pattern_rule
         assert matching_rules[0].step.__eq__(failure.step)

--- a/tests/unittests/functions/report/test_firewatch_functions_report_failure_matches_rule.py
+++ b/tests/unittests/functions/report/test_firewatch_functions_report_failure_matches_rule.py
@@ -68,3 +68,32 @@ class TestFailureMatchesRule(ReportBaseTest):
         assert (matching_rules[0].step == match_rule.step) and (
             matching_rules[0].failure_type == match_rule.failure_type
         )
+
+    def test_configuration_gets_failure_rules_with_two_matching_steps(self):
+        failure = Failure(failed_step="exact-failed-step", failure_type="test_failure")
+
+        match_rule = FailureRule(
+            rule_dict={
+                "step": "exact-failed-step",
+                "failure_type": "test_failure",
+                "classification": "NONE",
+                "jira_project": "NONE",
+            },
+        )
+        pattern_rule = FailureRule(
+            rule_dict={
+                "step": "exact-*",
+                "failure_type": "test_failure",
+                "classification": "NONE",
+                "jira_project": "NONE",
+            },
+        )
+        rules = [pattern_rule, match_rule]
+
+        matching_rules = self.report.failure_matches_rule(
+            failure=failure,
+            rules=rules,
+            default_jira_project=self.config.default_jira_project,
+        )
+        # Check if match_rule is sorted higher than pattern_rule
+        assert matching_rules[0].step.__eq__(failure.step)

--- a/tests/unittests/functions/report/test_firewatch_functions_report_failure_matches_rule.py
+++ b/tests/unittests/functions/report/test_firewatch_functions_report_failure_matches_rule.py
@@ -80,6 +80,14 @@ class TestFailureMatchesRule(ReportBaseTest):
                 "jira_project": "NONE",
             },
         )
+        different_type_rule = FailureRule(
+            rule_dict={
+                "step": "exact-failed-step",
+                "failure_type": "pod_failure",
+                "classification": "NONE",
+                "jira_project": "NONE",
+            },
+        )
         pattern_rule = FailureRule(
             rule_dict={
                 "step": "exact-*",
@@ -88,12 +96,13 @@ class TestFailureMatchesRule(ReportBaseTest):
                 "jira_project": "NONE",
             },
         )
-        rules = [pattern_rule, match_rule]
+        rules = [pattern_rule, different_type_rule, match_rule]
 
         matching_rules = self.report.failure_matches_rule(
             failure=failure,
             rules=rules,
             default_jira_project=self.config.default_jira_project,
         )
+
         # Check if match_rule is sorted higher than pattern_rule
         assert matching_rules[0].step.__eq__(failure.step)


### PR DESCRIPTION
Currently, if we have more then one matching rule for a failure, the code will take the first rule matched and consider the second a "duplicate" ticket.

**The goal** is to prioritize it with first check if there's a rule with the same name, otherwise use patterns or duplication.

Workflow example: 

1. We have two rules defined, one for exact- and one for exact-step. But, the rule for `exact-*` is first in the list of rules and `exact-step` is second.
2. A failure in `exact-step` is identified and paired with both rules.
3. In [this for loop](https://github.com/RedHatQE/firewatch/blob/main/src/report/report.py#L136), the first pair (`exact-*` rule) generates a bug.
4. In the second iteration of the for loop, the failure pair with the exact-step rule does not generate a ticket, since it'll be identified as a duplicated failure.