### PR TITLE
Remove cli requirement for existing path, allow configuration rules without "step"

### DIFF
--- a/src/commands/report.py
+++ b/src/commands/report.py
@@ -81,7 +81,7 @@ def validate_verbose_test_failure_reporting_ticket_limit(
     "--firewatch-config-path",
     help="The path to the firewatch configuration file",
     required=False,
-    type=click.Path(exists=True),
+    type=click.Path(),
 )
 @click.option(
     "--jira-config-path",

--- a/src/objects/configuration.py
+++ b/src/objects/configuration.py
@@ -214,8 +214,8 @@ class Configuration:
                 steps_map = {d.get("step"): d for d in config_data[key]}
             if key in base_config_data:
                 for step_dict in base_config_data[key]:
-                    step = step_dict["step"]
-                    if step not in steps_map.keys():
+                    step = step_dict.get("step")
+                    if step and step not in steps_map.keys():
                         # Check if user didn't mention a pattern that already overrides this step
                         if not any(fnmatch.fnmatch(step, k) for k in steps_map.keys()):
                             if key not in config_data:


### PR DESCRIPTION
Main changes:

1. Remove strict Click requirement for Firewatch config path to be an existing file
   - The cli accepts URLs
2. Allow the Firewatch configuration to include rules without "step"
   - Example:
   ```
   "success_rules":
    [
      {"jira_project": "PROJECT", "jira_additional_labels": ["!default"]}
    ]
   ```