### PR TITLE
Fix errors for unit tests

### DIFF
--- a/tests/unittests/objects/job/test_fail_with_test_failures_should_not_cause_failure_for_ignored_step.py
+++ b/tests/unittests/objects/job/test_fail_with_test_failures_should_not_cause_failure_for_ignored_step.py
@@ -42,8 +42,14 @@ def firewatch_config(monkeypatch, mock_jira, default_jira_project):
 
 
 @pytest.fixture
-def job_step_names():
-    yield ["openshift-pipelines-tests"]
+def job_step_names(monkeypatch):
+    step_names = ["openshift-pipelines-tests"]
+
+    def _mock_get_steps(*args, **kwargs):
+        return step_names
+
+    monkeypatch.setattr(Job, "_get_steps", _mock_get_steps)
+    return step_names
 
 
 @pytest.fixture(autouse=True)
@@ -75,7 +81,7 @@ def test_failure_artifacts_present(job_step_names, job_artifacts_dir):
 
 
 @pytest.fixture
-def job(firewatch_config):
+def job(firewatch_config, job_step_names):
     yield Job(
         name="periodic-ci-openshift-pipelines-release-tests-release-v1.15-openshift-pipelines-ocp4.17-lp-interop-openshift-pipelines-interop-aws",
         name_safe="openshift-pipelines-interop-aws",


### PR DESCRIPTION
Fixes below errors

```
src.objects.rule ERROR Environment variable $FIREWATCH_DEFAULT_JIRA_COMPONENT is not set.   
src.objects.rule ERROR Environment variable $FIREWATCH_DEFAULT_JIRA_ADDITIONAL_LABELS is not set. 

 =========================== short test summary info ============================    
479ERROR tests/unittests/functions/report/test_firewatch_functions_report_add_label_to_ticket_when_job_run_passes.py::test_fixtures_fake_job_has_open_bugs[LPTOCPCI-1805119554108526592]    
480ERROR tests/unittests/functions/report/test_firewatch_functions_report_add_label_to_ticket_when_job_run_passes.py::test_report_adds_passing_label_to_newly_passing_job_with_open_bugs[LPTOCPCI-1805119554108526592]    
481ERROR tests/unittests/objects/job/test_fail_with_test_failures_should_not_cause_failure_for_ignored_step.py::test_fail_with_test_failures_should_not_cause_failure_for_ignored_step[LPTOCPCI-1805119554108526592]   
 482ERROR tests/unittests/objects/job/test_fail_with_test_failures_should_not_cause_failure_for_ignored_step.py::test_fail_with_test_failures_should_cause_failure_unignored_step[LPTOCPCI-1805119554108526592]    
```

The last 4 errors occur due to no steps being found  by tests for sample jobs periodic-ci-openshift-pipelines-....-interop-aws
I have updated the mocking for tests which fixes the patching issue