### PR TITLE
Fix the timestamp path

### DIFF
--- a/src/objects/job.py
+++ b/src/objects/job.py
@@ -522,7 +522,7 @@ class Job:
         try:
             # Construct the blob path
             bucket = storage_client.bucket(gcs_bucket)
-            blob_path = f"{job_name}/{build_id}/started.json"
+            blob_path = f"logs/{job_name}/{build_id}/started.json"
             blob = bucket.blob(blob_path)
 
             # Get the timestamp from path


### PR DESCRIPTION
The full path to started.json (which contains job timestamp) needs to include the logs in path.
Otherwise [such error](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/logs/periodic-ci-oadp-qe-oadp-qe-automation-oadp-1.4-oadp1.4-ocp4.19-lp-interop-oadp-interop-aws/1911662362113347584/artifacts/oadp-interop-aws/firewatch-report-issues/build-log.txt) is generated